### PR TITLE
Do not include any executable since provided binaries are only for development

### DIFF
--- a/middleman-breadcrumbs.gemspec
+++ b/middleman-breadcrumbs.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |s|
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  s.executables   = []
   s.require_paths = ["lib"]
 end


### PR DESCRIPTION
After installing `middleman-breadcrumbs` gem there are two executables installed, that uses common names (`setup` and `console`) and could potentially break anything in the system. 

`setup`:

``` ruby
#!/Users/alsemyonov/.rbenv/versions/2.2.3/bin/ruby
#
# This file was generated by RubyGems.
#
# The application 'middleman-breadcrumbs' is installed as part of a gem, and
# this file is here to facilitate running it.
#

require 'rubygems'

version = ">= 0"

if ARGV.first
  str = ARGV.first
  str = str.dup.force_encoding("BINARY") if str.respond_to? :force_encoding
  if str =~ /\A_(.*)_\z/ and Gem::Version.correct?($1) then
    version = $1
    ARGV.shift
  end
end

gem 'middleman-breadcrumbs', version
load Gem.bin_path('middleman-breadcrumbs', 'setup', version)
```

`console`:

``` ruby
#!/Users/alsemyonov/.rbenv/versions/2.2.3/bin/ruby
#
# This file was generated by RubyGems.
#
# The application 'middleman-breadcrumbs' is installed as part of a gem, and
# this file is here to facilitate running it.
#

require 'rubygems'

version = ">= 0"

if ARGV.first
  str = ARGV.first
  str = str.dup.force_encoding("BINARY") if str.respond_to? :force_encoding
  if str =~ /\A_(.*)_\z/ and Gem::Version.correct?($1) then
    version = $1
    ARGV.shift
  end
end

gem 'middleman-breadcrumbs', version
load Gem.bin_path('middleman-breadcrumbs', 'console', version)
```

In reality they are not needed for middleman-breadcrumbs used in production, these scripts are only for development.
