### PR TITLE
Added 2 new options

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This gem has two configuration options, which are set in the [usual way for Midd
     Hide the homepage link. Default is <code>false</code>.
   </dd>
   <dt>
-    <code>:convert_last</code>
+    <code>:link_last</code>
   </dt>
   <dd>
     Convert the final page into a hyperlink. Default is <code>true</code>.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,18 @@ This gem has two configuration options, which are set in the [usual way for Midd
   <dd>
     Tag name (as a symbol) in which to wrap each breadcrumb level. Default is <code>nil</code>, which means no wrapping.
   </dd>
+  <dt>
+    <code>:hide_home</code>
+  </dt>
+  <dd>
+    Hide the homepage link. Default is <code>false</code>.
+  </dd>
+  <dt>
+    <code>:convert_last</code>
+  </dt>
+  <dd>
+    Convert the final page into a hyperlink. Default is <code>true</code>.
+  </dd>
 </dl>
 
 For example, if you wanted to wrap the breadcrumb levels in `<li>` elements and separate them with bullets, you would put the following in `config.rb`:

--- a/lib/middleman-breadcrumbs/breadcrumbs.rb
+++ b/lib/middleman-breadcrumbs/breadcrumbs.rb
@@ -9,6 +9,8 @@ class Breadcrumbs < Middleman::Extension
 
   option :separator, ' > ', 'Default separator between breadcrumb levels'
   option :wrapper, nil, 'Name of tag (as symbol) in which to wrap each breadcrumb level, or nil for no wrapping'
+  option :hide_home, false, 'Hide the homepage link'
+  option :convert_last, true, 'Convert the last page into a link'
 
   expose_to_template :breadcrumbs
 
@@ -16,17 +18,37 @@ class Breadcrumbs < Middleman::Extension
     super
     @separator = options.separator
     @wrapper = options.wrapper
+    @hide_home = options.hide_home
+    @convert_last = options.convert_last
   end
 
-  def breadcrumbs(page, separator: @separator, wrapper: @wrapper)
+  def breadcrumbs(page, separator: @separator, wrapper: @wrapper, hide_home: @hide_home, convert_last: @convert_last)
     hierarchy = [page]
     hierarchy.unshift hierarchy.first.parent while hierarchy.first.parent
-    hierarchy.collect {|page| wrap link_to(page.data.title, "/#{page.path}"), wrapper: wrapper }.join(h separator)
+    hierarchy.collect.with_index do |page, i|
+      if show_page(i, hide_home)
+        if convert_last_to_link(i, hierarchy.size, convert_last)
+          content_tag(:li, page.data.title)
+        else
+          wrap link_to(page.data.title, "#{page.url}"), wrapper: wrapper
+        end
+      end
+    end.join(h separator)
   end
 
   private
 
   def wrap(content, wrapper: nil)
     wrapper ? content_tag(wrapper) { content } : content
+  end
+
+  def show_page(page_index, hide_home)
+    return true unless hide_home
+    return true unless page_index == 0
+  end
+
+  def convert_last_to_link(page_index, size, convert_last)
+    return false unless !convert_last
+    return true if (page_index + 1) == size
   end
 end


### PR DESCRIPTION
`:home_home` determines whether to hide the homepage link or not
`:convert_last` determines whether to convert the final page into a link

This is what was required when updating GitLab's website 😃 
