### PR TITLE
Use Resource#url to honour directory indexes

### DIFF
--- a/lib/middleman-breadcrumbs/breadcrumbs.rb
+++ b/lib/middleman-breadcrumbs/breadcrumbs.rb
@@ -21,7 +21,7 @@ class Breadcrumbs < Middleman::Extension
   def breadcrumbs(page, separator: @separator, wrapper: @wrapper)
     hierarchy = [page]
     hierarchy.unshift hierarchy.first.parent while hierarchy.first.parent
-    hierarchy.collect {|page| wrap link_to(page.data.title, "/#{page.path}"), wrapper: wrapper }.join(h separator)
+    hierarchy.collect {|page| wrap link_to(page.data.title, page.url), wrapper: wrapper }.join(h separator)
   end
 
   private

--- a/spec/breadcrumbs_spec.rb
+++ b/spec/breadcrumbs_spec.rb
@@ -24,7 +24,7 @@ describe Breadcrumbs do
 
     describe 'top-level page' do
       it 'returns a link to the page' do
-        @helper.breadcrumbs(@page).must_equal link_to(@page.data.title, "/#{@page.path}")
+        @helper.breadcrumbs(@page).must_equal link_to(@page.data.title, @page.url)
       end
     end
 
@@ -110,7 +110,7 @@ describe Breadcrumbs do
 
   def breadcrumb_links
     [@grandparent, @parent, @page].collect do |level|
-      link_to level.data.title, "/#{level.path}"
+      link_to level.data.title, level.url
     end
   end
 


### PR DESCRIPTION
Resource#path does not work well with Middleman Pretty URLs,
see https://middlemanapp.com/advanced/pretty_urls

Using Resource#url fixes the problem as it follows the app configs.
