### PR TITLE
Fix links with directory_indexes

### DIFF
--- a/lib/middleman-breadcrumbs/breadcrumbs.rb
+++ b/lib/middleman-breadcrumbs/breadcrumbs.rb
@@ -20,11 +20,15 @@ class Breadcrumbs < Middleman::Extension
 
   def breadcrumbs(page, separator: @separator, wrapper: @wrapper)
     hierarchy = [page]
-    hierarchy.unshift hierarchy.first.parent while hierarchy.first.parent
-    hierarchy.collect {|page| wrap link_to(page.data.title, "/#{page.path}"), wrapper: wrapper }.join(h separator)
+    hierarchy.unshift(hierarchy.first.parent) while hierarchy.first.parent
+    hierarchy.collect { |parent| wrap(pretty_link_to(parent), wrapper: wrapper) }.join(escape_html(separator))
   end
 
   private
+
+  def pretty_link_to(page)
+    link_to(page.data.title, URI(page.url).path)
+  end
 
   def wrap(content, wrapper: nil)
     wrapper ? content_tag(wrapper) { content } : content

--- a/spec/breadcrumbs_spec.rb
+++ b/spec/breadcrumbs_spec.rb
@@ -116,7 +116,7 @@ describe Breadcrumbs do
 
   def page
     url = Faker::Internet.url # "https://example.com/lorem_ipsum"
-    path = URI(url).path[1..-1] # "lorem_ipsum"
+    path = URI(url).path.gsub %r{^/}, ''
     title = Faker::Lorem.sentence
     data = OpenStruct.new title: title
     OpenStruct.new data: data, path: path, url: url

--- a/spec/breadcrumbs_spec.rb
+++ b/spec/breadcrumbs_spec.rb
@@ -115,9 +115,10 @@ describe Breadcrumbs do
   end
 
   def page
-    path = Faker::Internet.url
+    url = Faker::Internet.url # "https://example.com/lorem_ipsum"
+    path = URI(url).path[1..-1] # "lorem_ipsum"
     title = Faker::Lorem.sentence
     data = OpenStruct.new title: title
-    OpenStruct.new data: data, path: path
+    OpenStruct.new data: data, path: path, url: url
   end
 end

--- a/spec/breadcrumbs_spec.rb
+++ b/spec/breadcrumbs_spec.rb
@@ -115,7 +115,7 @@ describe Breadcrumbs do
   end
 
   def page
-    url = Faker::Internet.url # "https://example.com/lorem_ipsum"
+    url = Faker::Internet.url
     path = URI(url).path.gsub %r{^/}, ''
     title = Faker::Lorem.sentence
     data = OpenStruct.new title: title


### PR DESCRIPTION
Here's a problem I found: when you add `activate :directory_indexes` to `config.rb`, the links in the breadcrumb stay the same.

If I have two pages, `/sources/foo/index.html.erb` and `/sources/foo/bar.html.erb` and I visit `/foo/bar/` in my browser (with pretty URLs) I expect to find links to `/foo/` and `/foo/bar/` in the breadcrumb. But that not the case, instead it's the usual `/foo/index.html` and `/foo/bar.html`.

Here is how to reproduce the problem on a fresh install:

```bash
middleman new foo
cd foo
mkdir source/foo
echo "---\ntitle: foo\n---\n" > source/foo/index.html.erb
echo "---\ntitle: bar\n---\n" > source/foo/bar.html.erb
echo "gem 'middleman-breadcrumbs'" >> Gemfile
echo "activate :breadcrumbs" >> config.rb
echo "activate :directory_indexes" >> config.rb
sed "s/<body>/<body><%= breadcrumbs(current_page) %>/g" source/layouts/layout.erb -i
bundle
bundle exec middleman
```

With this PR we get the expected links.

But there's just one catch that I found so far, without pretty URLs activated you still get `/foo/` instead of `/foo/index.html`. Though that isn't a problem for me.

P.S. I'd like to be able to run the test suite with `bundle exec rspec` to see if I break something and add a test for my PR but couldn't get it working. Sorry about that.